### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,6 @@ datasource db {
   provider          = "postgresql"
   url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
   directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-  shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 // Event model


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.